### PR TITLE
Fix dissoc arguments order

### DIFF
--- a/src/rmfu/core.clj
+++ b/src/rmfu/core.clj
@@ -46,7 +46,7 @@
         add-user! (db/add-user! body)]
     (println "attempting to post with" body)
     (if-not (or (empty? add-user!) (nil? add-user!))
-      (created (dissoc :password body))
+      (created (dissoc body :password))
       (conflict (str add-user!)))))
 
 (defn verify-email [req]


### PR DESCRIPTION
Submitting on behalf of @eldaromer, who discovered this bug, which was causing a `500` error on signup.