### PR TITLE
small changes to article persistance, associates articles to :author_id

### DIFF
--- a/src-cljs/rmfu_ui/createarticle.cljs
+++ b/src-cljs/rmfu_ui/createarticle.cljs
@@ -5,7 +5,7 @@
 
 (def ^{:private true} initial-article-state
   "The initial state for a new article"
-  {:title ""
+  {:title   ""
    :content ""})
 
 (def ^{:private true} new-article-state
@@ -16,152 +16,153 @@
   [e]
   (-> e .-target .-value))
 
-(defn get-identity-token []
+(def get-identity-token
   (.getItem (.-localStorage js/window) "rmfu-feed-identity-token"))
 
 (defn createarticle
   "The page for creating a new article."
   []
-
   [:div
-    [nav "create"]
-    [:div.container.jumbotron.largemain
-      [:div.row
-        [:div.col-lg-12
-          [:h1.text-center "Create Article"]
-          [:h4 "Title of Article"]
-          [:input.form-control
-            {:type "text",
-             :placeholder "Milk contains up to 10% of the following hormones upon bottling.",
-             :value (:title @new-article-state)
-             :on-change #(swap! new-article-state assoc :title (get-event-value %))}]
-          [:br]
-          ; [:h4
-          ;  "Link to Article (optional):"]
-          ; [:input.form-control
-          ;  {:type "text", :placeholder "http://www.milksafe.com/hormones.html", :value ""}]
+   [nav "create"]
+   [:div.container.jumbotron.largemain
+    [:div.row
+     [:div.col-lg-12
+      [:h1.text-center "Create Article"]
+      [:h4 "Title of Article"]
+      [:input.form-control
+       {:type        "text",
+        :placeholder "Milk contains up to 10% of the following hormones upon bottling.",
+        :value       (:title @new-article-state)
+        :on-change   #(swap! new-article-state assoc :title (get-event-value %))}]
+      [:br]
+      ; [:h4
+      ;  "Link to Article (optional):"]
+      ; [:input.form-control
+      ;  {:type "text", :placeholder "http://www.milksafe.com/hormones.html", :value ""}]
 
-          [:h4 "Description of Article (optional):"]
-          [:textarea.form-control
-            {:rows "14"
-            :value (:content @new-article-state)
-            :on-change #(swap! new-article-state assoc :content (get-event-value %))}]
+      [:h4 "Description of Article (optional):"]
+      [:textarea.form-control
+       {:rows      "14"
+        :value     (:content @new-article-state)
+        :on-change #(swap! new-article-state assoc :content (get-event-value %))}]
 
-          ; Keeping this stuff here for now
-          ; Not sure if we are going to include this funcitonality or not
-          
-          ; [:h4 "Relevant to these Regions"]
-          ; [:div.input-group
-          ;  [:input.form-control
-          ;   {:type "text", :placeholder "Enter Zip Code", :value ""}]
-          ;  [:span.input-group-addon.select-group
-          ;   [:select.c-select.select-item
-          ;    [:option
-          ;     "+1 mile"]
-          ;    [:option
-          ;     "+10 miles"]
-          ;    [:option
-          ;     "+50 miles"]]]
-          ;  [:div.input-group-btn
-          ;   [:button.btn.btn-default
-          ;    {:name "type", :type "button", :value "add"}
-          ;    "Add"]]]
-          ; [:br]
-          ; [:h4 "Relevant to these Topics"]
-          ; [:div.input-group
-          ;   [:input.form-control
-          ;     {:type "topics", :placeholder "Enter Keywords or select from suggestions below", :value ""}]
-          ;   [:span.input-group-btn
-          ;     [:button.btn.btn-default
-          ;       {:type "button", :value "add"}
-          ;       "Add"]]]
-          ; [:ul.list-inline
-          ;   [:li
-          ;     [:a
-          ;       {:href "#"}
-          ;       "Dairy"]]
-          ;   [:li
-          ;     [:a
-          ;       {:href "#"}
-          ;       "Organic"]]
-          ;   [:li
-          ;     [:a
-          ;       {:href "#"}
-          ;       "GMO"]]
-          ;   [:li
-          ;     [:a
-          ;       {:href "#"}
-          ;       "Fertilizer"]]
-          ;   [:li
-          ;     [:a
-          ;       {:href "#"}
-          ;       "Equipment"]]
-          ;   [:li
-          ;     [:a
-          ;       {:href "#"}
-          ;       "Poultry"]]
-          ;   [:li
-          ;     [:a
-          ;       {:href "#"}
-          ;       "Sustainable"]]
-          ;   [:li
-          ;     [:a
-          ;       {:href "#"}
-          ;       "Green"]]
-          ;   [:li
-          ;     [:a
-          ;       {:href "#"}
-          ;       "Pests"]]
-          ;   [:li
-          ;     [:a
-          ;       {:href "#"}
-          ;       "Tobacco"]]
-          ;   [:li
-          ;     [:a
-          ;       {:href "#"}
-          ;       "Fuel"]]
-          ;   [:li
-          ;     [:a
-          ;       {:href "#"}
-          ;       "Seeds"]]
-          ;   [:li
-          ;     [:a
-          ;       {:href "#"}
-          ;       "Wool"]]
-          ;   [:li
-          ;     [:a
-          ;       {:href "#"}
-          ;       "Solar"]]
-          ;   [:li
-          ;     [:a
-          ;       {:href "#"}
-          ;       "Wind"]]
-          ;   [:li
-          ;     [:a
-          ;       {:href "#"}
-          ;       "Legislation"]]
-          ;   [:li
-          ;     [:a
-          ;       {:href "#"}
-          ;       "Vegetables"]]
-          ;   [:li
-          ;     [:a
-          ;       {:href "#"}
-          ;       "Fruit"]]
-          ;   [:li
-          ;     [:a
-          ;       {:href "#"}
-          ;       "Polls"]]]
-          [:p.text-center
-            [:button.btn
-              {:name "type"
-               :type "button"
-               :value "create_article"
-               :on-click (fn []
-                           (POST "/api/articles"
-                                 {:headers         {:identity (get-identity-token)
-                                                    :Content-Type "application/json"}
-                                  :body            (.stringify js/JSON (clj->js @new-article-state))
-                                  :error-handler   #(js/alert %)
-                                  :handler         #(js/alert (str "success. Created at: " %))}))}
-              "Create the Article"]]]]]])
+      ; Keeping this stuff here for now
+      ; Not sure if we are going to include this funcitonality or not
+
+      ; [:h4 "Relevant to these Regions"]
+      ; [:div.input-group
+      ;  [:input.form-control
+      ;   {:type "text", :placeholder "Enter Zip Code", :value ""}]
+      ;  [:span.input-group-addon.select-group
+      ;   [:select.c-select.select-item
+      ;    [:option
+      ;     "+1 mile"]
+      ;    [:option
+      ;     "+10 miles"]
+      ;    [:option
+      ;     "+50 miles"]]]
+      ;  [:div.input-group-btn
+      ;   [:button.btn.btn-default
+      ;    {:name "type", :type "button", :value "add"}
+      ;    "Add"]]]
+      ; [:br]
+      ; [:h4 "Relevant to these Topics"]
+      ; [:div.input-group
+      ;   [:input.form-control
+      ;     {:type "topics", :placeholder "Enter Keywords or select from suggestions below", :value ""}]
+      ;   [:span.input-group-btn
+      ;     [:button.btn.btn-default
+      ;       {:type "button", :value "add"}
+      ;       "Add"]]]
+      ; [:ul.list-inline
+      ;   [:li
+      ;     [:a
+      ;       {:href "#"}
+      ;       "Dairy"]]
+      ;   [:li
+      ;     [:a
+      ;       {:href "#"}
+      ;       "Organic"]]
+      ;   [:li
+      ;     [:a
+      ;       {:href "#"}
+      ;       "GMO"]]
+      ;   [:li
+      ;     [:a
+      ;       {:href "#"}
+      ;       "Fertilizer"]]
+      ;   [:li
+      ;     [:a
+      ;       {:href "#"}
+      ;       "Equipment"]]
+      ;   [:li
+      ;     [:a
+      ;       {:href "#"}
+      ;       "Poultry"]]
+      ;   [:li
+      ;     [:a
+      ;       {:href "#"}
+      ;       "Sustainable"]]
+      ;   [:li
+      ;     [:a
+      ;       {:href "#"}
+      ;       "Green"]]
+      ;   [:li
+      ;     [:a
+      ;       {:href "#"}
+      ;       "Pests"]]
+      ;   [:li
+      ;     [:a
+      ;       {:href "#"}
+      ;       "Tobacco"]]
+      ;   [:li
+      ;     [:a
+      ;       {:href "#"}
+      ;       "Fuel"]]
+      ;   [:li
+      ;     [:a
+      ;       {:href "#"}
+      ;       "Seeds"]]
+      ;   [:li
+      ;     [:a
+      ;       {:href "#"}
+      ;       "Wool"]]
+      ;   [:li
+      ;     [:a
+      ;       {:href "#"}
+      ;       "Solar"]]
+      ;   [:li
+      ;     [:a
+      ;       {:href "#"}
+      ;       "Wind"]]
+      ;   [:li
+      ;     [:a
+      ;       {:href "#"}
+      ;       "Legislation"]]
+      ;   [:li
+      ;     [:a
+      ;       {:href "#"}
+      ;       "Vegetables"]]
+      ;   [:li
+      ;     [:a
+      ;       {:href "#"}
+      ;       "Fruit"]]
+      ;   [:li
+      ;     [:a
+      ;       {:href "#"}
+      ;       "Polls"]]]
+      [:p.text-center
+       [:button.btn
+        {:name     "type"
+         :type     "button"
+         :value    "create_article"
+         :on-click (fn []
+                     (POST "/api/articles"
+                           {:headers       {:identity get-identity-token}
+                            :format        :json
+                            :params        @new-article-state
+                            :error-handler #(js/alert %)
+                            :handler       (fn [res]
+                                             (js/alert (str "success. Created at: " res))
+                                             (reset! new-article-state initial-article-state))}))}
+        "Create the Article"]]]]]])

--- a/src/rmfu/core.clj
+++ b/src/rmfu/core.clj
@@ -113,9 +113,9 @@
                                :header-params [identity :- String]
                                (let [identity (get-in request [:headers "identity"])
                                      unsigned-token (auth/unsign-token identity)]
-                                 (if (not (nil? unsigned-token))
+                                 (if unsigned-token
                                    (let [user (db/find-user-by-username (:username unsigned-token))
-                                         persisted-article (db/add-article! (:body request) user)]
+                                         persisted-article (db/add-article! (:body request) (:email user))]
                                      (created (str "/articles/" (:_id persisted-article))))
                                    (unauthorized {:error "not auth"}))))
                         auth-backend)))
@@ -129,7 +129,7 @@
             (PUT "/reset-password-from-form" [] reset-password-from-form!)
             (PUT "/update-user-profile" [] update-user-profile)
             (GET "/verify-email/:email" [] verify-email)
-            (route/resources "/assets")           ;; serve /assets for chosen lib jar
+            (route/resources "/assets")                     ;; serve /assets for chosen lib jar
             (route/not-found (not-found "Resource not found")))
 
 (defroutes app-routes
@@ -143,7 +143,7 @@
                      :access-control-allow-methods [:get :put :post :delete])
           params-middleware/wrap-params
           (json-middleware/wrap-json-body {:keywords? true})
-          (wrap-file "resources/public")))              ;; server static files from this directory
+          (wrap-file "resources/public")))                  ;; server static files from this directory
 
 (defn -main [port]
   (jetty/run-jetty app {:port (Integer. port)}))

--- a/src/rmfu/persistance.clj
+++ b/src/rmfu/persistance.clj
@@ -76,16 +76,12 @@
 (defn add-article!
   "Adds a new article to the database.
   Warning: This method is not idempotent currently."
-  [article author]
+  [article author_id]
   (let [{:keys [title content]} article
         article-oid (ObjectId.)
-        article-doc {:_id article-oid
-                     :title title
-                     :content content
-                     :created (java.util.Date.)}
-        author-oid  (:_id author)]
-    ; NOTE: Since MongoDB doesn't have transactions this ordering
-    ; assumes that it is okay to have articles without authors
-    (mc/insert db "articles" article-doc)
-    (mc/update-by-id db "users" author-oid {$push {"articles" article-oid}})
-    article-doc))
+        article-doc {:author_id author_id
+                     :_id       article-oid
+                     :title     title
+                     :content   content
+                     :created   (java.util.Date.)}]
+    (acknowledged? (mc/insert db "articles" article-doc))))


### PR DESCRIPTION
**Proposal:**
- took some advice from this mongo-db guide: 
https://docs.mongodb.org/manual/tutorial/model-referenced-one-to-many-relationships-between-documents/ esp. the last example where a collection does not necessary keep references to other docs;
instead there is a *reference* that connects the two, i.e. `:author_id`

**Other changes:**
- clears article state after successfull posting

Sorry for the line diffs in the cljs files, 
my editor is way too good at formatting code automatically ;)

:cc @wdoug @brettevans @switzersc @dkoloditch 