### PR TITLE
Article Validation via Schema

### DIFF
--- a/app.json
+++ b/app.json
@@ -14,6 +14,9 @@
     },
     "RMFU_FROM_EMAIL":{
       "required":true
+    },
+    "RMFU_SECRET": {
+      "required": true
     }
   },
   "addons":[

--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,9 @@
                  [cljsjs/chosen "1.4.2-1"]
                  [cljsjs/jquery "2.1.4-0"]
                  [cljsjs/fixed-data-table "0.4.6-0"]
-                 [timothypratley/reanimated "0.1.4"]]
+                 [timothypratley/reanimated "0.1.4"]
+                 [metosin/schema-tools "0.7.0"]
+                 [prismatic/schema "1.0.3"]]
 
   :plugins [[lein-cljsbuild "1.1.0"]
             [lein-figwheel "0.4.1"]
@@ -80,4 +82,4 @@
 
   :clean-targets ^{:protect false} ["resources/public/js/compiled" "target"]
 
-  :source-paths ["src" "src-cljs"])
+  :source-paths ["src" "src-cljs" "src-cljc"])

--- a/src-cljc/rmfu/validation.cljc
+++ b/src-cljc/rmfu/validation.cljc
@@ -1,0 +1,10 @@
+(ns rmfu.validation
+  (:require [schema.core :as s :include-macros true]))
+
+(def Article
+  "Defines a schema for a Article data type"
+  {:title   s/Str
+   :content s/Str})
+
+(defn article [a]
+  (s/validate Article a))

--- a/src-cljs/rmfu_ui/about.cljs
+++ b/src-cljs/rmfu_ui/about.cljs
@@ -1,0 +1,23 @@
+(ns rmfu-ui.about
+  (:require [rmfu-ui.nav :refer [nav]]))
+
+(defn about []
+  [:div
+   [nav]
+   [:div.container.jumbotron.large-main
+    [:div.row
+     [:div.col-lg-12
+      [:h1.text-center "About Feed"]
+      [:p "Feed is collaboration between Rocky Mountain Farmers Union and Code for Denver to help provide a place for active engagement within RMFU's communities"]
+      [:h2 "Rocky Mountain Farmers Union"]
+      [:p "Rocky Mountain Farmers Union is an advocate for family farmers and ranchers, local communities, and consumers. We are a progressive grassroots organization whose members determine our priorities. Founded in 1907, Rocky Mountain Farmers Union represent farm and ranch families in Colorado, New Mexico and Wyoming. Working together with similar state chapters across America, we are the heart and soul of the National Farmers Union."]
+      [:h2 "Code for Denver"]
+      [:p "We believe technology and innovation are powerful tools we can all use to make our community an even more spectacular place to live.
+
+We are a diverse group of volunteers who are passionate about leveraging the power of technology to benefit the people of our Denver community.
+
+We tap into the potential of technology to tackle issues like food systems, food security, economic development, safety and justice.
+
+We recognize that we are a part of a much larger movement to address some of the challenges that face our planet. In order to collectively have the biggest impact, we work in partnership and collaboration with both local government, and the international network of Code for America brigades of which we are a part.
+
+We also team up with local nonprofits and other active community members to make sure we understand the issues, to brainstorm technology-based solutions, and to actualize our ideas in ways that aim for measurable community benefit."]]]]])

--- a/src-cljs/rmfu_ui/core.cljs
+++ b/src-cljs/rmfu_ui/core.cljs
@@ -13,6 +13,7 @@
     [rmfu-ui.feed :refer [feed]]
     [rmfu-ui.admin :refer [admin]]
     [rmfu-ui.nav :refer [nav]]
+    [rmfu-ui.about :refer [about]]
     [secretary.core :as secretary :include-macros true]
     [rmfu-ui.welcome :refer [welcome-component-wrapper]])
   (:import goog.History))
@@ -295,6 +296,9 @@
 
 (secretary/defroute "/admin" []
                     (session/put! :current-page #'admin))
+
+(secretary/defroute "/about" []
+		    (session/put! :current-page #'about))
 
 (secretary/defroute "*" []
                     (session/put! :current-page #'four-o-four))

--- a/src-cljs/rmfu_ui/createarticle.cljs
+++ b/src-cljs/rmfu_ui/createarticle.cljs
@@ -1,16 +1,27 @@
 (ns rmfu-ui.createarticle
   (:require [rmfu-ui.nav :refer [nav]]
+            [rmfu.validation :as validate]
+            [rmfu-ui.alert :refer [alert]]
             [reagent.core :as reagent]
             [ajax.core :refer [POST]]))
 
 (def ^{:private true} initial-article-state
   "The initial state for a new article"
-  {:title   ""
-   :content ""})
+  {:title   nil
+   :content nil})
 
 (def ^{:private true} new-article-state
   "The state of the create article page."
   (reagent/atom initial-article-state))
+
+(def app-state
+  (reagent/atom {:alert {:display false
+                         :message nil
+                         :title   nil}}))
+
+(defn alert-update-fn [title]
+  (swap! app-state assoc-in [:alert :title] title)
+  (swap! app-state update-in [:alert :display] not))
 
 (defn get-event-value
   [e]
@@ -27,6 +38,7 @@
    [:div.container.jumbotron.largemain
     [:div.row
      [:div.col-lg-12
+      [alert :error app-state]
       [:h1.text-center "Create Article"]
       [:h4 "Title of Article"]
       [:input.form-control
@@ -157,12 +169,15 @@
          :type     "button"
          :value    "create_article"
          :on-click (fn []
-                     (POST "/api/articles"
-                           {:headers       {:identity get-identity-token}
-                            :format        :json
-                            :params        @new-article-state
-                            :error-handler #(js/alert %)
-                            :handler       (fn [res]
-                                             (js/alert (str "success. Created at: " res))
-                                             (reset! new-article-state initial-article-state))}))}
+                     (try
+                       (validate/article @new-article-state)
+                       (POST "/api/articles"
+                             {:headers       {:identity get-identity-token}
+                              :format        :json
+                              :params        @new-article-state
+                              :error-handler #(js/alert %)
+                              :handler       (fn [res]
+                                               (js/alert (str "success. Created at: " res))
+                                               (reset! new-article-state initial-article-state))})
+                       (catch js/Object _ (alert-update-fn "Missing article title"))))}
         "Create the Article"]]]]]])

--- a/src/rmfu/persistance.clj
+++ b/src/rmfu/persistance.clj
@@ -7,6 +7,7 @@
             [buddy.hashers :as hasher]
             [rmfu.email :as email]
             [environ.core :refer [env]]
+            [rmfu.validation :as validate]
             [slingshot.slingshot :refer [try+]])
   (:import org.bson.types.ObjectId))
 
@@ -120,10 +121,12 @@
   Warning: This method is not idempotent currently."
   [article author-email]
   (let [{:keys [title content]} article
+        is-article-valid? (validate/article article)
         article-oid (ObjectId.)
         article-doc {:author-email author-email
                      :_id          article-oid
                      :title        title
                      :content      content
                      :created      (java.util.Date.)}]
-    (acknowledged? (mc/insert db "articles" article-doc))))
+    (when is-article-valid?
+      (acknowledged? (mc/insert db "articles" article-doc)))))


### PR DESCRIPTION
Closes #46

- adds schema dependency
- adds **src-cljc** namespace (we can now use this namespace for sharing code front-end /  back-end, not the .CLJC extension)
- adds simple Article validation front-end (on POST) and back-end (on CREATE)
- warns user of missing Article title