### PR TITLE
Fix reset password form

### DIFF
--- a/src-cljs/rmfu_ui/core.cljs
+++ b/src-cljs/rmfu_ui/core.cljs
@@ -30,6 +30,7 @@
 (defn request-password-reset [profile]
   (POST "/send-reset-password-email"
         {:params        {:email (:email profile)}
+         :format        :json
          :error-handler #(js/alert %)
          :handler       (fn [res]
                           (do


### PR DESCRIPTION
Without explicitly specifying the format as json,
the default will use transit. The backend, however,
is expecting json.