### PR TITLE
Redirects to 404 on missing article

### DIFF
--- a/resources/public/css/style.css
+++ b/resources/public/css/style.css
@@ -139,14 +139,25 @@ p.articlelink a {
 
 .big-text{
     display: block;
-    width: 16rem;
-    height: 16rem;
-    font-size: 6.5rem;
-    line-height: 7rem;
+    width: 20rem;
+    height: 20rem;
+    font-size: 6.0rem;
     color: #fff;
     text-align: center;
     cursor: default;
     background-color: tomato;
+}
+
+.big-text > p {
+    margin-bottom: 0rem;
+}
+
+.big-text-subtitle {
+    font-size: 1.15rem;
+}
+
+.big-text-subtitle > a {
+    color: white;
 }
 
 /* BEGINS 18F Alert component CSS

--- a/src-cljs/rmfu_ui/article.cljs
+++ b/src-cljs/rmfu_ui/article.cljs
@@ -2,7 +2,8 @@
   (:require [rmfu-ui.utils :refer [get-identity-token]]
             [reagent.core :as reagent]
             [reagent.session :as session]
-            [ajax.core :refer [PUT GET]]))
+            [ajax.core :refer [PUT GET]]
+            [secretary.core :as secretary]))
 
 (defn article []
   (let [article-state (reagent/atom {:title ""
@@ -11,7 +12,9 @@
         fetch-article (fn [article-id]
                         (GET (str "api/articles/" article-id)
                              {:headers         {:identity (get-identity-token)}
-                              :error-handler   #(js/alert %)
+                              :error-handler   (fn [res]
+                                                 (session/put! :error-msg (get-in res [:response :error]))
+                                                 (secretary/dispatch! "/oops"))
                               :response-format :json
                               :keywords?       true
                               :handler         #(reset! article-state %)}))]

--- a/src-cljs/rmfu_ui/core.cljs
+++ b/src-cljs/rmfu_ui/core.cljs
@@ -92,8 +92,12 @@
    [nav]
    [(session/get :current-page)]])
 
-(defn four-o-four [msg]
-  [:div.container.jumbotron.big-text [:u (or msg 404)]])
+(defn four-o-four []
+  [:div.container.jumbotron.big-text
+   [:p "oops!"]
+   [:p.big-text-subtitle [:u (or (session/get! :error-msg)
+                                 "that page doesn’t exist...")]]
+   [:p.big-text-subtitle [:a {:href "/"} [:b "Return to homepage ?"]]]])
 
 (secretary/defroute "/" []
                     (session/put! :current-page #'sign-in))
@@ -135,6 +139,9 @@
 (secretary/defroute "/new-password" [query-params]
                     (session/put! :token (:token query-params))
                     (session/put! :current-page #'new-password-component))
+
+(secretary/defroute "/oops" []
+                    (session/put! :current-page #'four-o-four))
 
 (secretary/defroute "*" []
                     (session/put! :current-page #'four-o-four))

--- a/src/rmfu/core.clj
+++ b/src/rmfu/core.clj
@@ -161,7 +161,7 @@
                                 (if unsigned-token
                                   (if-let [article (db/find-article-by-id id)]
                                     (ok article)
-                                    (not-found (str "No article found with id: " id)))
+                                    (not-found {:error (str "No article found with id: " id)}))
                                   (unauthorized {:error "not auth"}))))
                         auth-backend)
 


### PR DESCRIPTION
closes #79 
- we can now pass a message to the `404` page

<img width="491" alt="screen shot 2015-12-07 at 1 19 16 am" src="https://cloud.githubusercontent.com/assets/144226/11622239/3a2b70b6-9c81-11e5-9ca9-dd1870340784.png">
